### PR TITLE
Automatically create PlayerBody

### DIFF
--- a/addons/godot-xr-tools/assets/PlayerBody.gd
+++ b/addons/godot-xr-tools/assets/PlayerBody.gd
@@ -94,11 +94,43 @@ class SortProviderByOrder:
 	static func sort_by_order(a, b) -> bool:
 		return true if a.order < b.order else false
 
+# Get our origin node, make sure we have consistent code here
+func _get_origin_node() -> ARVROrigin:
+	var node : ARVROrigin = get_node_or_null(origin) if origin else get_parent()
+	return node
+
+# Get our camera node
+func _get_camera_node() -> ARVRCamera:
+	# if we have set a node, try and use it
+	var node : ARVRCamera
+	
+	if camera:
+		node = get_node_or_null(camera)
+		if node:
+			return node
+
+	var o : ARVROrigin = _get_origin_node()
+	if !o:
+		return null
+
+	# else get by default name 
+	node = o.get_node_or_null("ARVRCamera")
+	if node:
+		return node
+
+	# else find the first camera child
+	for child in o.get_children():
+		if child is ARVRCamera:
+			return child
+
+	# no luck
+	return null
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	# Get the origin and camera nodes
-	origin_node = get_node(origin) if origin else get_parent()
-	camera_node = get_node(camera) if camera else origin_node.get_node("ARVRCamera")
+	origin_node = _get_origin_node()
+	camera_node = _get_camera_node()
 
 	# Get the movement providers ordered by increasing order
 	_movement_providers = get_tree().get_nodes_in_group("movement_providers")
@@ -264,12 +296,12 @@ func _apply_velocity_and_control(delta: float):
 # - Maximum slope is valid
 func _get_configuration_warning():
 	# Check the origin node
-	var test_origin_node = get_node_or_null(origin) if origin else get_parent()
+	var test_origin_node = _get_origin_node()
 	if !test_origin_node or !test_origin_node is ARVROrigin:
 		return "Unable to find ARVR Origin node"
 
 	# Check the camera node
-	var test_camera_node = get_node_or_null(camera) if camera else test_origin_node.get_node("ARVRCamera")
+	var test_camera_node = _get_camera_node()
 	if !test_camera_node or !test_camera_node is ARVRCamera:
 		return "Unable to find ARVR Camera node"
 

--- a/addons/godot-xr-tools/functions/MovementProvider.gd
+++ b/addons/godot-xr-tools/functions/MovementProvider.gd
@@ -18,12 +18,75 @@ extends Node
 ## Enable movement provider
 export var enabled := true
 
+# Get our origin node, we should be in a branch of this
+func get_arvr_origin() -> ARVROrigin:
+	var parent = get_parent()
+	while parent:
+		if parent is ARVROrigin:
+			return parent
+		parent = parent.get_parent()
+	
+	return null
+
+# Get our player body, this should be a node on our ARVROrigin node.
+func get_player_body() -> PlayerBody:
+	# get our origin node
+	var arvr_origin = get_arvr_origin()
+	if !arvr_origin:
+		return null
+
+	# checking if the node exists before fetching it prevents error spam
+	if !arvr_origin.has_node("PlayerBody"):
+		return null
+
+	# get our player node
+	var player_body = arvr_origin.get_node("PlayerBody")
+	if player_body and player_body is PlayerBody:
+		return player_body
+
+	return null
+
+# If missing we need to add our player body 
+func _create_player_body_node():
+	# get our origin node
+	var arvr_origin = get_arvr_origin()
+	if !arvr_origin:
+		return
+
+	# Double check if it hasn't already been created by another movement function
+	var player_body = get_player_body()
+	if !player_body:
+		# create our player body node and add it into our tree
+		player_body = preload("res://addons/godot-xr-tools/assets/PlayerBody.tscn")
+		player_body = player_body.instance()
+		player_body.set_name("PlayerBody")
+		arvr_origin.add_child(player_body)
+		player_body.set_owner(arvr_origin.owner)
+
+# Function run when node is added to scene
+func _ready():
+	# If we're in the editor, help the user out by creating our player body node automatically when needed.
+	if Engine.editor_hint:
+		var player_body = get_player_body()
+		if !player_body:
+			# This call needs to be deferred, we can't add nodes during scene construction
+			call_deferred("_create_player_body_node")
+
 # Override this function to apply motion to the PlayerBody
 func physics_movement(delta: float, player_body: PlayerBody):
 	pass
 
 # This method verifies the MovementProvider has a valid configuration.
 func _get_configuration_warning():
+	# Verify we're within the tree of an ARVROrigin node
+	var arvr_origin = get_arvr_origin()
+	if !arvr_origin:
+		return "This node must be within a branch on an ARVROrigin node"
+
+	var player_body = get_player_body()
+	if !player_body:
+		return "Missing player body node on the ARVROrigin"
+
 	# Verify movement provider is in the correct group
 	if !is_in_group("movement_providers"):
 		return "Movement provider not in 'movement_providers' group"


### PR DESCRIPTION
Ok Malcolm,

This is just some extra code that ensures the player body node is automatically created when you add a movement function to the scene tree. 

I'm also in favor of starting to remove the export variables for origin and camera and having the movement functions query the player body for this information. The more the code can infer from adding nodes in a place that provides context, the cleaner the setup, the less the user has to worry about.